### PR TITLE
Some assorted parsing fixes to allow parsing the manifests of each mod in AllTheMods 6 without issues

### DIFF
--- a/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/ForgeAccessTransformer.java
+++ b/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/ForgeAccessTransformer.java
@@ -90,16 +90,21 @@ public class ForgeAccessTransformer {
 
 				String targetClassName = words.get(1);
 
+				TransformedClass targetClass = classes.computeIfAbsent(targetClassName, name -> new TransformedClass(name, Finalization.KEEP, AccessLevel.KEEP));
+
 				if (words.size() == 2) {
-					if (classes.containsKey(targetClassName)) {
+					if (targetClass.getFinalization() != Finalization.KEEP || targetClass.getAccessLevel() != AccessLevel.KEEP) {
 						throw new ManifestParseException("two transformations of the same class!");
 					}
 
-					classes.put(targetClassName, new TransformedClass(targetClassName, finalization, accessLevel));
+					// It's possible for an access transformation to a field within a class to be stated before an
+					// access transformation on the class itself, therefore we have to be able to change the access of
+					// the TransformedClass even after it has been created. Unfortunately it means that we can't keep
+					// the fields final, but oh well.
+					targetClass.setFinalization(finalization);
+					targetClass.setAccessLevel(accessLevel);
 				} else {
 					// Method or field
-					TransformedClass targetClass = classes.computeIfAbsent(targetClassName, name -> new TransformedClass(name, Finalization.KEEP, AccessLevel.KEEP));
-
 					String memberWord = words.get(2);
 
 					if (memberWord.equals("*()")) {

--- a/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/ForgeAccessTransformer.java
+++ b/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/ForgeAccessTransformer.java
@@ -2,12 +2,14 @@ package net.patchworkmc.manifest.accesstransformer.v2;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import net.patchworkmc.manifest.accesstransformer.v2.exception.MissingMappingException;
 import net.patchworkmc.manifest.accesstransformer.v2.flags.AccessLevel;
@@ -65,24 +67,30 @@ public class ForgeAccessTransformer {
 					strippedLine = line;
 				}
 
+				// Trim any leading or trailing whitespace
+				strippedLine = strippedLine.trim();
+
 				if (strippedLine.isEmpty()) {
 					continue;
 				}
 
-				String[] words = strippedLine.split(" ");
+				// Remove empty substrings since they represent whitespace
+				List<String> words = Arrays.stream(strippedLine.split(" "))
+						.filter(string -> !string.isEmpty())
+						.collect(Collectors.toList());
 
 				// make sure our length is correct
-				if (words.length < 2 || words.length > 3) {
-					throw new ManifestParseException("expected size of 2 or 3, got " + words.length);
+				if (words.size() < 2 || words.size() > 3) {
+					throw new ManifestParseException("Invalid AT line: expected size of 2 or 3, got " + words.size());
 				}
 
-				String modifier = words[0];
+				String modifier = words.get(0);
 				Finalization finalization = getFinalization(modifier);
 				AccessLevel accessLevel = getAccessLevel(modifier, finalization);
 
-				String targetClassName = words[1];
+				String targetClassName = words.get(1);
 
-				if (words.length == 2) {
+				if (words.size() == 2) {
 					if (classes.containsKey(targetClassName)) {
 						throw new ManifestParseException("two transformations of the same class!");
 					}
@@ -92,7 +100,7 @@ public class ForgeAccessTransformer {
 					// Method or field
 					TransformedClass targetClass = classes.computeIfAbsent(targetClassName, name -> new TransformedClass(name, Finalization.KEEP, AccessLevel.KEEP));
 
-					String memberWord = words[2];
+					String memberWord = words.get(2);
 
 					if (memberWord.equals("*()")) {
 						targetClass.acceptMethodWildcard(new TransformedWildcardMember(accessLevel, finalization));

--- a/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/Transformed.java
+++ b/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/Transformed.java
@@ -7,8 +7,8 @@ import net.patchworkmc.manifest.api.Remapper;
 
 public abstract class Transformed {
 	private final String name;
-	private final AccessLevel accessLevel;
-	private final Finalization finalization;
+	protected AccessLevel accessLevel;
+	protected Finalization finalization;
 
 	protected Transformed(String name, AccessLevel accessLevel, Finalization finalization) {
 		this.name = name;

--- a/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/TransformedClass.java
+++ b/src/main/java/net/patchworkmc/manifest/accesstransformer/v2/TransformedClass.java
@@ -44,6 +44,14 @@ public class TransformedClass extends Transformed {
 		return Collections.unmodifiableSet(methods);
 	}
 
+	void setFinalization(Finalization finalization) {
+		this.finalization = finalization;
+	}
+
+	void setAccessLevel(AccessLevel accessLevel) {
+		this.accessLevel = accessLevel;
+	}
+
 	public TransformedClass remap(Remapper remapper, Consumer<MissingMappingException> errorLogger) throws MissingMappingException {
 		String remappedName = remapper.remapClassName(getName());
 		Set<TransformedField> remappedFields = new HashSet<>();

--- a/src/main/java/net/patchworkmc/manifest/mod/ModManifest.java
+++ b/src/main/java/net/patchworkmc/manifest/mod/ModManifest.java
@@ -58,8 +58,18 @@ public class ModManifest {
 
 			// Parse the dependency mapping
 
-			Map<String, Object> dependencies =
-					ManifestParseHelper.getMap(data, "dependencies", false);
+			Map<String, Object> dependencies;
+
+			try {
+				dependencies = ManifestParseHelper.getMap(data, "dependencies", false);
+			} catch (ManifestParseException e) {
+				// If the dependencies list is of the wrong type, Forge silently ignores the dependency list instead of
+				// revealing any sort of error
+				//
+				// This is needed to properly patch the following mod:
+				// https://www.curseforge.com/minecraft/mc-mods/spice-of-life-carrot-edition
+				dependencies = null;
+			}
 
 			if (dependencies != null) {
 				for (Map.Entry<String, Object> dependencySet : dependencies.entrySet()) {


### PR DESCRIPTION
Also fixes some issues related to whitespace and mixed class / field AT entries when parsing access transformers